### PR TITLE
Hanoi University of Science and Technology

### DIFF
--- a/lib/domains/vn/edu/hust/sis.txt
+++ b/lib/domains/vn/edu/hust/sis.txt
@@ -1,0 +1,2 @@
+Đại Học Bách Khoa Hà Nội
+Hanoi University of Science and Technology


### PR DESCRIPTION
Update latest domain. In 2017, they changed the domain from `students.hust.edu.vn` to `sis.hust.edu.vn`.